### PR TITLE
[Chore] 이미지 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,11 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-
 	// swagger
-	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+	// s3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/zerobibim/flory/domain/Image/controller/ImageConroller.java
+++ b/src/main/java/zerobibim/flory/domain/Image/controller/ImageConroller.java
@@ -1,0 +1,24 @@
+package zerobibim.flory.domain.Image.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import zerobibim.flory.domain.Image.dto.response.ImageIdResponse;
+import zerobibim.flory.domain.Image.service.ImageService;
+import zerobibim.flory.global.common.ApiPayload.ApiResponse;
+
+@Tag(name = "Image API", description = "이미지 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/image")
+public class ImageConroller {
+    private final ImageService imageService;
+
+    @PostMapping
+    @Operation(summary = "이미지 생성 API")
+    public ApiResponse<ImageIdResponse> createImage(@RequestPart("flower_image") MultipartFile flowerImage) {
+        return ApiResponse.onSuccess(imageService.createImage(flowerImage));
+    }
+}

--- a/src/main/java/zerobibim/flory/domain/Image/dto/response/ImageIdResponse.java
+++ b/src/main/java/zerobibim/flory/domain/Image/dto/response/ImageIdResponse.java
@@ -1,0 +1,12 @@
+package zerobibim.flory.domain.Image.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ImageIdResponse {
+    private Long ImageId;
+}

--- a/src/main/java/zerobibim/flory/domain/Image/entity/Image.java
+++ b/src/main/java/zerobibim/flory/domain/Image/entity/Image.java
@@ -1,0 +1,31 @@
+package zerobibim.flory.domain.Image.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Where;
+import zerobibim.flory.global.common.BaseTime;
+
+@Entity
+@Getter
+@Where(clause = "deleted_at is null")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Image extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String url;
+
+    private Long senderId;
+
+    private Boolean isNFT;
+
+    @Builder
+    public Image(String url) {
+        this.url = url;
+        this.isNFT = Boolean.FALSE;
+    }
+}

--- a/src/main/java/zerobibim/flory/domain/Image/entity/Image.java
+++ b/src/main/java/zerobibim/flory/domain/Image/entity/Image.java
@@ -21,12 +21,21 @@ public class Image extends BaseTime {
 
     private Long senderId;
 
+    private Long receiverId;
+
     private Boolean isNFT;
 
     @Builder
     public Image(String url) {
         this.url = url;
         this.senderId = null;
+        this.receiverId = null;
         this.isNFT = Boolean.FALSE;
+    }
+
+    public void updateImage(Long senderId, Long receiverId) {
+        this.senderId = senderId;
+        this.receiverId = receiverId;
+        this.isNFT = Boolean.TRUE;
     }
 }

--- a/src/main/java/zerobibim/flory/domain/Image/entity/Image.java
+++ b/src/main/java/zerobibim/flory/domain/Image/entity/Image.java
@@ -26,6 +26,7 @@ public class Image extends BaseTime {
     @Builder
     public Image(String url) {
         this.url = url;
+        this.senderId = null;
         this.isNFT = Boolean.FALSE;
     }
 }

--- a/src/main/java/zerobibim/flory/domain/Image/mapper/ImageMapper.java
+++ b/src/main/java/zerobibim/flory/domain/Image/mapper/ImageMapper.java
@@ -1,0 +1,13 @@
+package zerobibim.flory.domain.Image.mapper;
+
+import org.springframework.stereotype.Component;
+import zerobibim.flory.domain.Image.entity.Image;
+
+@Component
+public class ImageMapper {
+    public Image toEntity(String url) {
+        return Image.builder()
+                .url(url)
+                .build();
+    }
+}

--- a/src/main/java/zerobibim/flory/domain/Image/repository/ImageRepository.java
+++ b/src/main/java/zerobibim/flory/domain/Image/repository/ImageRepository.java
@@ -2,7 +2,11 @@ package zerobibim.flory.domain.Image.repository;
 
 import zerobibim.flory.domain.Image.entity.Image;
 
+import java.util.Optional;
+
 public interface ImageRepository {
 
     Image save(Image image);
+
+    Optional<Image> findImageById(Long id);
 }

--- a/src/main/java/zerobibim/flory/domain/Image/repository/ImageRepository.java
+++ b/src/main/java/zerobibim/flory/domain/Image/repository/ImageRepository.java
@@ -1,0 +1,8 @@
+package zerobibim.flory.domain.Image.repository;
+
+import zerobibim.flory.domain.Image.entity.Image;
+
+public interface ImageRepository {
+
+    Image save(Image image);
+}

--- a/src/main/java/zerobibim/flory/domain/Image/repository/JpaImageRepository.java
+++ b/src/main/java/zerobibim/flory/domain/Image/repository/JpaImageRepository.java
@@ -1,0 +1,7 @@
+package zerobibim.flory.domain.Image.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import zerobibim.flory.domain.Image.entity.Image;
+
+public interface JpaImageRepository extends JpaRepository<Image, Long>, ImageRepository {
+}

--- a/src/main/java/zerobibim/flory/domain/Image/service/ImageService.java
+++ b/src/main/java/zerobibim/flory/domain/Image/service/ImageService.java
@@ -9,12 +9,15 @@ import zerobibim.flory.domain.Image.entity.Image;
 import zerobibim.flory.domain.Image.mapper.ImageMapper;
 import zerobibim.flory.domain.Image.repository.ImageRepository;
 import zerobibim.flory.global.common.ApiPayload.code.status.ErrorStatus;
+import zerobibim.flory.global.common.EntityLoader;
 import zerobibim.flory.global.common.ExceptionHandler;
 import zerobibim.flory.utils.S3ImageComponent;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
-public class ImageService {
+public class ImageService implements EntityLoader<Image, Long> {
 
     private final ImageMapper imageMapper;
     private final ImageRepository imageRepository;
@@ -34,5 +37,18 @@ public class ImageService {
             throw new ExceptionHandler(ErrorStatus.IMAGE_BLANK);
         }
         return s3ImageComponent.uploadImage("flower-image", flowerImage);
+    }
+
+    @Transactional
+    public void makeNft(Long imageId, Long senderId, Long receiverId) {
+        Image image = loadEntity(imageId);
+        image.updateImage(senderId, receiverId);
+    }
+
+    @Override
+    public Image loadEntity(Long id) {
+        Optional<Image> image = imageRepository.findImageById(id);
+        if(image.isEmpty()) throw new ExceptionHandler(ErrorStatus.IMAGE_NOT_FOUND);
+        return image.get();
     }
 }

--- a/src/main/java/zerobibim/flory/domain/Image/service/ImageService.java
+++ b/src/main/java/zerobibim/flory/domain/Image/service/ImageService.java
@@ -1,0 +1,38 @@
+package zerobibim.flory.domain.Image.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import zerobibim.flory.domain.Image.dto.response.ImageIdResponse;
+import zerobibim.flory.domain.Image.entity.Image;
+import zerobibim.flory.domain.Image.mapper.ImageMapper;
+import zerobibim.flory.domain.Image.repository.ImageRepository;
+import zerobibim.flory.global.common.ApiPayload.code.status.ErrorStatus;
+import zerobibim.flory.global.common.ExceptionHandler;
+import zerobibim.flory.utils.S3ImageComponent;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final ImageMapper imageMapper;
+    private final ImageRepository imageRepository;
+    private final S3ImageComponent s3ImageComponent;
+
+    @Transactional
+    public ImageIdResponse createImage(final MultipartFile flowerImage) {
+        String imageUrl = uploadImage(flowerImage);
+
+        Image newImage = imageRepository.save(
+                imageMapper.toEntity(imageUrl));
+        return new ImageIdResponse(newImage.getId());
+    }
+
+    private String uploadImage(final MultipartFile flowerImage) {
+        if(flowerImage.isEmpty()) {
+            throw new ExceptionHandler(ErrorStatus.IMAGE_BLANK);
+        }
+        return s3ImageComponent.uploadImage("flower-image", flowerImage);
+    }
+}

--- a/src/main/java/zerobibim/flory/domain/flower/controller/FlowerController.java
+++ b/src/main/java/zerobibim/flory/domain/flower/controller/FlowerController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import zerobibim.flory.domain.flower.dto.request.FlowerInsertImageRequest;
 import zerobibim.flory.domain.flower.dto.request.FlowerCreateReqeust;
 import zerobibim.flory.domain.flower.dto.request.FlowerUpdateRequest;
 import zerobibim.flory.domain.flower.dto.response.FlowerDetailResponse;
@@ -40,6 +41,17 @@ public class FlowerController {
     @Operation(summary = "꽃 수정 API")
     public ApiResponse<FlowerIdResponse> updateFlower(@RequestBody FlowerUpdateRequest request) {
         return ApiResponse.onSuccess(flowerService.updateFlower(request));
+    }
+
+    /**
+     * 꽃 이미지를 업데이트합니다.
+     * @param request 업데이트 할 꽃과 이미지에 대한 DTO입니다.
+     * @return 업데이트된 꽃의 id가 반환됩니다.
+     */
+    @PostMapping("/image")
+    @Operation(summary = "꽃 이미지 생성 API")
+    public ApiResponse<FlowerIdResponse> insertImage(@RequestBody FlowerInsertImageRequest request) {
+        return ApiResponse.onSuccess(flowerService.insertImage(request));
     }
 
     /**

--- a/src/main/java/zerobibim/flory/domain/flower/dto/request/FlowerInsertImageRequest.java
+++ b/src/main/java/zerobibim/flory/domain/flower/dto/request/FlowerInsertImageRequest.java
@@ -1,0 +1,13 @@
+package zerobibim.flory.domain.flower.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FlowerInsertImageRequest {
+    private Long flowerId;
+    private Long imageId;
+}

--- a/src/main/java/zerobibim/flory/domain/flower/entity/Flower.java
+++ b/src/main/java/zerobibim/flory/domain/flower/entity/Flower.java
@@ -3,6 +3,7 @@ package zerobibim.flory.domain.flower.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Where;
+import zerobibim.flory.domain.Image.entity.Image;
 import zerobibim.flory.global.common.BaseTime;
 
 @Entity
@@ -23,6 +24,10 @@ public class Flower extends BaseTime {
 
     @Column(nullable = false)
     private Long price;
+
+    @OneToOne
+    @JoinColumn
+    private Image image;
 
     @Builder
     public Flower(String name, String description, Long price) {

--- a/src/main/java/zerobibim/flory/domain/flower/entity/Flower.java
+++ b/src/main/java/zerobibim/flory/domain/flower/entity/Flower.java
@@ -40,4 +40,8 @@ public class Flower extends BaseTime {
         this.description = description;
         this.price = price;
     }
+
+    public void updateFlowerImage(Image image) {
+        this.image = image;
+    }
 }

--- a/src/main/java/zerobibim/flory/domain/flower/service/FlowerService.java
+++ b/src/main/java/zerobibim/flory/domain/flower/service/FlowerService.java
@@ -3,6 +3,9 @@ package zerobibim.flory.domain.flower.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import zerobibim.flory.domain.Image.entity.Image;
+import zerobibim.flory.domain.Image.service.ImageService;
+import zerobibim.flory.domain.flower.dto.request.FlowerInsertImageRequest;
 import zerobibim.flory.domain.flower.dto.request.FlowerCreateReqeust;
 import zerobibim.flory.domain.flower.dto.request.FlowerUpdateRequest;
 import zerobibim.flory.domain.flower.dto.response.FlowerDetailResponse;
@@ -22,6 +25,7 @@ import java.util.Optional;
 public class FlowerService implements EntityLoader<Flower, Long> {
     private final FlowerRepository flowerRepository;
     private final FlowerMapper flowerMapper;
+    private final ImageService imageService;
 
     public FlowerIdResponse createFlower(FlowerCreateReqeust reqeust) {
         // 중복 꽃 여부 확인
@@ -42,6 +46,15 @@ public class FlowerService implements EntityLoader<Flower, Long> {
         Flower flower = loadEntity(request.getFlowerId());
 
         flower.update(request.getDescription(), request.getPrice());
+        return new FlowerIdResponse(flower.getId());
+    }
+
+    @Transactional
+    public FlowerIdResponse insertImage(FlowerInsertImageRequest request) {
+        Flower flower = loadEntity(request.getFlowerId());
+        Image image = imageService.loadEntity(request.getImageId());
+
+        flower.updateFlowerImage(image);
         return new FlowerIdResponse(flower.getId());
     }
 

--- a/src/main/java/zerobibim/flory/domain/purchase/dto/request/PurchaseCreateRequest.java
+++ b/src/main/java/zerobibim/flory/domain/purchase/dto/request/PurchaseCreateRequest.java
@@ -14,7 +14,6 @@ public class PurchaseCreateRequest {
     private String receiverNickname;
     private Long flowerId;
     private int flowerQuentity;
-    private String nftComment;
     private LocalDate receiveDate;
     private int deliveryTip;
     private int totalPrice;

--- a/src/main/java/zerobibim/flory/domain/purchase/entity/Purchase.java
+++ b/src/main/java/zerobibim/flory/domain/purchase/entity/Purchase.java
@@ -39,8 +39,6 @@ public class Purchase extends BaseTime {
 
     private int flowerCnt;
 
-    private String nftComment;
-
     private int deliveryTip;
 
     private int totalPrice;
@@ -50,7 +48,7 @@ public class Purchase extends BaseTime {
     @Builder
     public Purchase(Member sender, Member receiver, LocalDate receiveDate,
                     Flower flower, String receiverName, String receiverAddress,
-                    int flowerCnt, String nftComment, int deliveryTip, int totalPrice) {
+                    int flowerCnt, int deliveryTip, int totalPrice) {
         this.sender = sender;
         this.receiver = receiver;
         this.receiveDate = receiveDate;
@@ -58,7 +56,6 @@ public class Purchase extends BaseTime {
         this.receiverAddress = receiverAddress;
         this.flower = flower;
         this.flowerCnt = flowerCnt;
-        this.nftComment = nftComment;
         this.deliveryTip = deliveryTip;
         this.totalPrice = totalPrice;
         this.isDelivered = Boolean.FALSE;

--- a/src/main/java/zerobibim/flory/domain/purchase/mapper/PurchaseMapper.java
+++ b/src/main/java/zerobibim/flory/domain/purchase/mapper/PurchaseMapper.java
@@ -11,7 +11,7 @@ import java.time.LocalDate;
 public class PurchaseMapper {
     public Purchase toEntity(Member sender, Member receiver, LocalDate receiveDate,
                              Flower flower, String receiverName, String receiverAddress,
-                             int flowerCnt, String nftComment, int deliveryTip, int totalPrice) {
+                             int flowerCnt, int deliveryTip, int totalPrice) {
         return Purchase.builder()
                 .sender(sender)
                 .receiver(receiver)
@@ -20,7 +20,6 @@ public class PurchaseMapper {
                 .receiverName(receiverName)
                 .receiverAddress(receiverAddress)
                 .flowerCnt(flowerCnt)
-                .nftComment(nftComment)
                 .deliveryTip(deliveryTip)
                 .totalPrice(totalPrice)
                 .build();

--- a/src/main/java/zerobibim/flory/domain/purchase/service/PurchaseService.java
+++ b/src/main/java/zerobibim/flory/domain/purchase/service/PurchaseService.java
@@ -2,6 +2,7 @@ package zerobibim.flory.domain.purchase.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import zerobibim.flory.domain.Image.service.ImageService;
 import zerobibim.flory.domain.flower.entity.Flower;
 import zerobibim.flory.domain.flower.service.FlowerService;
 import zerobibim.flory.domain.member.entity.Member;
@@ -24,16 +25,19 @@ public class PurchaseService implements EntityLoader<Purchase, Long> {
     private final PurchaseMapper purchaseMapper;
     private final MemberService memberService;
     private final FlowerService flowerService;
+    private final ImageService imageService;
 
     public PurchaseIdResponse createPurchase(PurchaseCreateRequest request) {
         Member sender = memberService.loadEntity(request.getMemberId());
         Member receiver = memberService.findMemberByNickname(request.getReceiverNickname());
         Flower flower = flowerService.loadEntity(request.getFlowerId());
+        if(flower.getImage() == null) throw new ExceptionHandler(ErrorStatus.NO_IMAGE_IN_FLOWER);
+        imageService.makeNft(flower.getImage().getId(), sender.getId(), receiver.getId());
 
         Purchase newPurchase = purchaseRepository.save(
                 purchaseMapper.toEntity(
                         sender, receiver, request.getReceiveDate(), flower, request.getReceiverName(), request.getReceiverAddress(),
-                        request.getFlowerQuentity(), request.getNftComment(), request.getDeliveryTip(), request.getTotalPrice()
+                        request.getFlowerQuentity(), request.getDeliveryTip(), request.getTotalPrice()
                 ));
 
         return new PurchaseIdResponse(newPurchase.getId());

--- a/src/main/java/zerobibim/flory/global/common/ApiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/zerobibim/flory/global/common/ApiPayload/code/status/ErrorStatus.java
@@ -33,6 +33,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 테스트 관련 응답
     TEST_EXCEPTION(HttpStatus.BAD_REQUEST, "TEST4001", "테스트를 위한 에러 코드"),
+
+    // 이미지 관련 응답
+    IMAGE_BLANK(HttpStatus.BAD_REQUEST, "IMAGE4001", "이미지 파일이 없습니다."),
     ;
 
 

--- a/src/main/java/zerobibim/flory/global/common/ApiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/zerobibim/flory/global/common/ApiPayload/code/status/ErrorStatus.java
@@ -25,6 +25,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 꽃 관련 응답
     FLOWER_NOT_FOUND(HttpStatus.BAD_REQUEST, "FLOWER4001", "존재하지 않는 꽃입니다."),
     FLOWER_EXISTED(HttpStatus.BAD_REQUEST, "FLOWER4002","이미 존재하는 꽃입니다."),
+    NO_IMAGE_IN_FLOWER(HttpStatus.BAD_REQUEST, "FLOWER4003", "꽃에 이미지가 존재하지 않습니다."),
     // 기념일 관련 응답
 
     // 구매 관련 응답
@@ -36,6 +37,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 이미지 관련 응답
     IMAGE_BLANK(HttpStatus.BAD_REQUEST, "IMAGE4001", "이미지 파일이 없습니다."),
+    IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "IMAGE4002", "존재하지 않는 이미지입니다."),
     ;
 
 

--- a/src/main/java/zerobibim/flory/global/config/S3Config.java
+++ b/src/main/java/zerobibim/flory/global/config/S3Config.java
@@ -1,0 +1,28 @@
+package zerobibim.flory.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/zerobibim/flory/utils/S3ImageComponent.java
+++ b/src/main/java/zerobibim/flory/utils/S3ImageComponent.java
@@ -1,0 +1,64 @@
+package zerobibim.flory.utils;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Component
+public class S3ImageComponent {
+    private final AmazonS3Client amazonS3Client;
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadImage(String category, MultipartFile multipartFile) {
+        // 파일명
+        String fileName = createFileName(category, Objects.requireNonNull(multipartFile.getOriginalFilename()));
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(multipartFile.getContentType());
+
+        // S3에 업로드
+        try {
+            amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, multipartFile.getInputStream(), objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException ignored) {
+        }
+
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    /**
+     * 파일명 생성
+     * @param category
+     * @param originalFileName
+     * @return 작명된 파일 이름
+     */
+    public String createFileName(String category, String originalFileName) {
+        int fileExtensionIndex = originalFileName.lastIndexOf(".");
+        String fileExtension = originalFileName.substring(fileExtensionIndex);
+        String fileName = originalFileName.substring(0, fileExtensionIndex);
+        String random = String.valueOf(UUID.randomUUID());
+
+        return category + "/" + fileName + "_" + random + fileExtension;
+    }
+
+    /**
+     * 이미지 삭제
+     * @param fileUrl
+     */
+    public void deleteImage(String fileUrl) {
+        String[] deleteUrl = fileUrl.split("/", 4);
+        amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, deleteUrl[3]));
+    }
+}


### PR DESCRIPTION
## 추가/수정한 기능 설명
1. S3 세팅
2. 이미지 생성 API 생성
3. 꽃 이미지 업데이트 API 생성
4. 구매 API로직 변경
   - 구매 시 꽃 이미지를 NFT로 만듦(isNFT 필드 값 true로)
   - 이미지 sender 및 receiver id 삽입
<br>


## check list
- [x] issue number를 브랜치 앞에 추가 했나요?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?
